### PR TITLE
Use cross-env to let template work on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add a reference to generated CSS file `tailwind.css` in your `index.html`
 
 ### Referencing Tailwind in a Sutil App
 
-Use Sutil's `class'` property to specify the Tailwind classes:
+Use Sutil's `class'` property from Sutil.CoreElements to specify the Tailwind classes:
 
 ```fs
     Html.div [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "dotnet fable       src/App --run npm run pack:prod",
     "pack": "npm run tailwind && webpack serve",
     "pack:prod": "npm run tailwind && webpack --mode production",
-    "tailwind": "NODE_ENV=production tailwindcss build -o public/tailwind.css"
+    "tailwind": "cross-env NODE_ENV=production tailwindcss build -o public/tailwind.css"
   },
   "dependencies": {
     "webpack": "^5.11.0",
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.2.5",
+    "cross-env": "^7.0.3",
     "postcss": "^8.2.10",
     "tailwindcss": "^3.2.4"
   }


### PR DESCRIPTION
Currently `npm run start` has issues on Windows because of the set environment variable.
This adds [cross-env](https://www.npmjs.com/package/cross-env) to deal with that cross-platform.
There's also a small enhancement to the README.md which might help newcomers.